### PR TITLE
Use mediaDevices.getUserMedia

### DIFF
--- a/src/React/SessionDescriptionhandler.js
+++ b/src/React/SessionDescriptionhandler.js
@@ -4,7 +4,7 @@ var WebRTC = require('react-native-webrtc');
 var {
   RTCPeerConnection,
   MediaStream,
-  getUserMedia,
+  mediaDevices,
 } = WebRTC;
 
 /**
@@ -51,7 +51,7 @@ var SessionDescriptionHandler = function(logger, observer, options) {
 
   this.WebRTC = {
     MediaStream: MediaStream,
-    getUserMedia: getUserMedia,
+    getUserMedia: mediaDevices.getUserMedia,
     RTCPeerConnection: RTCPeerConnection
   };
 


### PR DESCRIPTION
Importing `getUserMedia` directly from WebRTC does not work as it's  use has changed to `mediaDevices.getUserMedia` in `react-native-webrtc`. The change can be seen here: (https://github.com/oney/react-native-webrtc/commit/a6d25587f536b59afb46e8184320e187e4336a32#diff-168726dbe96b3ce427e7fedce31bb0bc).

